### PR TITLE
BLADE-8 ⁃ Improvement to the Foreach Regular Expression to Support Functions, and ...

### DIFF
--- a/src/Radic/BladeExtensions/BladeExtender.php
+++ b/src/Radic/BladeExtensions/BladeExtender.php
@@ -102,11 +102,11 @@ class BladeExtender
 
     public function openForeach($value, Application $app, Compiler $blade)
     {
-        $matcher = '/@foreach\s*\((.[0-9a-zA-Z_\->]+(?:\([^)]*\))?)\s?(.*)\)/';
+        $matcher = '/@foreach(\s*)\((.[0-9a-zA-Z_\->]+(?:\([^)]*\))?)\s?(.*)\)/';
         return preg_replace($matcher,
-        '<?php
-        \Radic\BladeExtensions\Extensions\ForEachManager::newLoop($1);
-        foreach($1 $2):
+        '$1<?php
+        \Radic\BladeExtensions\Extensions\ForEachManager::newLoop($2);
+        foreach($2 $3):
         $loop = \Radic\BladeExtensions\Extensions\ForEachManager::loop();
         ?>', $value);
     }


### PR DESCRIPTION
...Properties

This new regex will support more variation instead of just a plain variable like so:

```
@foreach($value->getArray(true) as $key => $val)
```

The current matcher will screw this up badly.
One item this will not support is nested functions...
That will require a lot more effort.

My test criteria which I verified on rubular.com is:

```
@foreach(true)
@foreach($array)
@foreach($array as $key => $val)
@foreach(getArray())
@foreach(getArray() as $key => $val)
@foreach($value->array)
@foreach($value->array as $key => $val)
@foreach($value->getArray())
@foreach($value->getArray() as $key => $val)
@foreach($value->getArray(true) as $key => $val)
```