### PR TITLE
Fix v1.2.0

### DIFF
--- a/src/Radic/BladeExtensions/BladeExtender.php
+++ b/src/Radic/BladeExtensions/BladeExtender.php
@@ -81,10 +81,10 @@ class BladeExtender
 
 
     # LOOPS
-    // regex test: http://regex101.com/r/qH9eO7/2
+    // regex test: https://regex101.com/r/qH9eO7/3
     public function openForeach($value, Application $app, Compiler $blade)
     {
-        $matcher = '/@foreach\((.*)(?:\sas)(.*)\)/';
+        $matcher = '/@foreach(\s*)\((.*)(?:\sas)(.*)\)/';
         return preg_replace($matcher,
             '<?php
         \Radic\BladeExtensions\Directives\ForeachLoopFactory::newLoop($1);

--- a/src/Radic/BladeExtensions/BladeExtender.php
+++ b/src/Radic/BladeExtensions/BladeExtender.php
@@ -39,13 +39,13 @@ class BladeExtender
     // regex:: http://regex101.com/r/yN1gO5/2
     public function addSet($value, Application $app, Compiler $blade)
     {
-        return preg_replace('/@set\((?:\$|(?:\'))(.*?)(?:\'|),\s(.*)\)/', '<?php \$$1 = $2; ?>', $value);
+        return preg_replace('/@set(\s*)\((?:\$|(?:\'))(.*?)(?:\'|),\s(.*)\)/', '<?php \$$1 = $2; ?>', $value);
     }
 
     public function addUnset($value, Application $app, Compiler $blade)
     {
 
-        return preg_replace('/@unset\((?:\$|(?:\'))(.*?)(?:\'|)\)/', '<?php unset(\$$1); ?>', $value);
+        return preg_replace('/@unset(\s*)\((?:\$|(?:\'))(.*?)(?:\'|)\)/', '<?php unset(\$$1); ?>', $value);
     }
 
     public function addDebug($value, Application $app, Compiler $blade)
@@ -63,7 +63,7 @@ class BladeExtender
     public function openMacro($value, Application $app, Compiler $blade)
     {
         //$matcher = '/@macro\([\'\"](\w*)[\'\"]\)/';
-        $matcher = '/@macro\([\'"]([\w\d]*)[\'"],(.*)\)/';
+        $matcher = '/@macro(\s*)\([\'"]([\w\d]*)[\'"],(.*)\)/';
         return preg_replace($matcher, '<?php HTML::macro("$1", function($2){ ', $value);
     }
 
@@ -75,7 +75,7 @@ class BladeExtender
 
     public function DoMacro($value, Application $app, Compiler $blade)
     {
-        $matcher = '/@domacro\([\'"]([\w\d]*)[\'"],(.*)\)/';
+        $matcher = '/@domacro(\s*)\([\'"]([\w\d]*)[\'"],(.*)\)/';
         return preg_replace($matcher, '<?php echo HTML::$1($2); ?>', $value);
     }
 


### PR DESCRIPTION
This fixes the regex of **v1.2 of blade-extension** for Laravel 4.2.* in order to allow whitespaces in instructions like "@foreach (...)" for example.
**This shouldn't be merged with develop branch but with v1.2.0 tag.**