### PR TITLE
Avoid critical error on loop when $current is false.

### DIFF
--- a/src/Radic/BladeExtensions/Core/LoopFactory.php
+++ b/src/Radic/BladeExtensions/Core/LoopFactory.php
@@ -45,7 +45,7 @@ abstract class LoopFactory
     public static function loop()
     {
         $current = end(static::$stack);
-        $current->before();
+        if ($current) $current->before();
         return $current;
     }
 


### PR DESCRIPTION
Avoid error 'Call to a member function before() on a non-object' when $current is false on loop.