### PR TITLE
Fix ambiguous class resolution warning

### DIFF
--- a/src/Facades/BladeString.php
+++ b/src/Facades/BladeString.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\Facade;
  * @link               http://robin.radic.nl/blade-extensions
  *
  */
-class Markdown extends Facade
+class BladeString extends Facade
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Fixes Composer ambiguous class resolution warning:

```
Warning: Ambiguous class resolution, "Radic\BladeExtensions\Facades\Markdown" 
was found in both  "/var/www/vendor/radic/blade-extensions/src/Facades/BladeString.php" and 
"/var/www/vendor/radic/blade-extensions/src/Facades/Markdown.php", the first will be used.
```

Which also resulted in Markdown facades not working correctly.